### PR TITLE
Methods do not return models

### DIFF
--- a/src/ClickUpClient.cs
+++ b/src/ClickUpClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using ClickUpApi.Models;
 
 namespace ClickUpApi
 {
@@ -16,7 +17,7 @@ namespace ClickUpApi
             _personalApiToken = personalApiToken;
         }
 
-        public async Task<string> CreateTaskAsync(string listId, string taskName, string taskDescription)
+        public async Task<Models.Task> CreateTaskAsync(string listId, string taskName, string taskDescription)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, $"https://api.clickup.com/api/v2/list/{listId}/task")
             {
@@ -32,11 +33,10 @@ namespace ClickUpApi
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var jsonDocument = JsonDocument.Parse(content);
-            return jsonDocument.RootElement.GetProperty("id").GetString();
+            return JsonSerializer.Deserialize<Models.Task>(content);
         }
 
-        public async Task<string> GetTaskAsync(string taskId)
+        public async Task<Models.Task> GetTaskAsync(string taskId)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"https://api.clickup.com/api/v2/task/{taskId}");
             request.Headers.Add("Authorization", _personalApiToken);
@@ -45,11 +45,10 @@ namespace ClickUpApi
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var jsonDocument = JsonDocument.Parse(content);
-            return jsonDocument.RootElement.GetProperty("name").GetString();
+            return JsonSerializer.Deserialize<Models.Task>(content);
         }
 
-        public async Task<string> UpdateTaskAsync(string taskId, string taskName, string taskDescription)
+        public async Task<Models.Task> UpdateTaskAsync(string taskId, string taskName, string taskDescription)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, $"https://api.clickup.com/api/v2/task/{taskId}")
             {
@@ -65,8 +64,7 @@ namespace ClickUpApi
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var jsonDocument = JsonDocument.Parse(content);
-            return jsonDocument.RootElement.GetProperty("id").GetString();
+            return JsonSerializer.Deserialize<Models.Task>(content);
         }
 
         public async Task DeleteTaskAsync(string taskId)
@@ -78,7 +76,7 @@ namespace ClickUpApi
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<string> GetAuthorizedUserAsync()
+        public async Task<Models.User> GetAuthorizedUserAsync()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "https://api.clickup.com/api/v2/user");
             request.Headers.Add("Authorization", _personalApiToken);
@@ -87,11 +85,10 @@ namespace ClickUpApi
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var jsonDocument = JsonDocument.Parse(content);
-            return jsonDocument.RootElement.GetProperty("username").GetString();
+            return JsonSerializer.Deserialize<Models.User>(content);
         }
 
-        public async Task<string> GetAuthorizedTeamsAsync()
+        public async Task<Models.Team[]> GetAuthorizedTeamsAsync()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "https://api.clickup.com/api/v2/team");
             request.Headers.Add("Authorization", _personalApiToken);
@@ -101,7 +98,7 @@ namespace ClickUpApi
 
             var content = await response.Content.ReadAsStringAsync();
             var jsonDocument = JsonDocument.Parse(content);
-            return jsonDocument.RootElement.GetProperty("teams").ToString();
+            return JsonSerializer.Deserialize<Models.Team[]>(jsonDocument.RootElement.GetProperty("teams").ToString());
         }
     }
 }

--- a/src/IClickUpClient.cs
+++ b/src/IClickUpClient.cs
@@ -4,11 +4,11 @@ namespace ClickUpApi
 {
     public interface IClickUpClient
     {
-        Task<string> CreateTaskAsync(string listId, string taskName, string taskDescription);
-        Task<string> GetTaskAsync(string taskId);
-        Task<string> UpdateTaskAsync(string taskId, string taskName, string taskDescription);
+        Task<Models.Task> CreateTaskAsync(string listId, string taskName, string taskDescription);
+        Task<Models.Task> GetTaskAsync(string taskId);
+        Task<Models.Task> UpdateTaskAsync(string taskId, string taskName, string taskDescription);
         Task DeleteTaskAsync(string taskId);
-        Task<string> GetAuthorizedUserAsync();
-        Task<string> GetAuthorizedTeamsAsync();
+        Task<Models.User> GetAuthorizedUserAsync();
+        Task<Models.Team[]> GetAuthorizedTeamsAsync();
     }
 }

--- a/tests/ClickupClientTests.cs
+++ b/tests/ClickupClientTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using ClickUpApi.Models;
 
 namespace ClickUpApi.Tests
 {
@@ -28,7 +29,12 @@ namespace ClickUpApi.Tests
             var listId = "test_list_id";
             var taskName = "test_task_name";
             var taskDescription = "test_task_description";
-            var expectedTaskId = "test_task_id";
+            var expectedTask = new Task
+            {
+                Id = "test_task_id",
+                Name = taskName,
+                Description = taskDescription
+            };
 
             _httpMessageHandlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -39,14 +45,16 @@ namespace ClickUpApi.Tests
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($"{{\"id\": \"{expectedTaskId}\"}}")
+                    Content = new StringContent($"{{\"id\": \"{expectedTask.Id}\", \"name\": \"{expectedTask.Name}\", \"description\": \"{expectedTask.Description}\"}}")
                 });
 
             // Act
-            var taskId = await _clickUpClient.CreateTaskAsync(listId, taskName, taskDescription);
+            var task = await _clickUpClient.CreateTaskAsync(listId, taskName, taskDescription);
 
             // Assert
-            Assert.Equal(expectedTaskId, taskId);
+            Assert.Equal(expectedTask.Id, task.Id);
+            Assert.Equal(expectedTask.Name, task.Name);
+            Assert.Equal(expectedTask.Description, task.Description);
         }
 
         [Fact]
@@ -54,7 +62,11 @@ namespace ClickUpApi.Tests
         {
             // Arrange
             var taskId = "test_task_id";
-            var expectedTaskName = "test_task_name";
+            var expectedTask = new Task
+            {
+                Id = taskId,
+                Name = "test_task_name"
+            };
 
             _httpMessageHandlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -65,14 +77,15 @@ namespace ClickUpApi.Tests
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($"{{\"name\": \"{expectedTaskName}\"}}")
+                    Content = new StringContent($"{{\"id\": \"{expectedTask.Id}\", \"name\": \"{expectedTask.Name}\"}}")
                 });
 
             // Act
-            var taskName = await _clickUpClient.GetTaskAsync(taskId);
+            var task = await _clickUpClient.GetTaskAsync(taskId);
 
             // Assert
-            Assert.Equal(expectedTaskName, taskName);
+            Assert.Equal(expectedTask.Id, task.Id);
+            Assert.Equal(expectedTask.Name, task.Name);
         }
 
         [Fact]
@@ -82,7 +95,12 @@ namespace ClickUpApi.Tests
             var taskId = "test_task_id";
             var taskName = "updated_task_name";
             var taskDescription = "updated_task_description";
-            var expectedTaskId = "test_task_id";
+            var expectedTask = new Task
+            {
+                Id = taskId,
+                Name = taskName,
+                Description = taskDescription
+            };
 
             _httpMessageHandlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -93,14 +111,16 @@ namespace ClickUpApi.Tests
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($"{{\"id\": \"{expectedTaskId}\"}}")
+                    Content = new StringContent($"{{\"id\": \"{expectedTask.Id}\", \"name\": \"{expectedTask.Name}\", \"description\": \"{expectedTask.Description}\"}}")
                 });
 
             // Act
-            var updatedTaskId = await _clickUpClient.UpdateTaskAsync(taskId, taskName, taskDescription);
+            var updatedTask = await _clickUpClient.UpdateTaskAsync(taskId, taskName, taskDescription);
 
             // Assert
-            Assert.Equal(expectedTaskId, updatedTaskId);
+            Assert.Equal(expectedTask.Id, updatedTask.Id);
+            Assert.Equal(expectedTask.Name, updatedTask.Name);
+            Assert.Equal(expectedTask.Description, updatedTask.Description);
         }
 
         [Fact]
@@ -136,7 +156,11 @@ namespace ClickUpApi.Tests
         public async Task GetAuthorizedUserAsync_ReturnsUsername()
         {
             // Arrange
-            var expectedUsername = "test_username";
+            var expectedUser = new User
+            {
+                Id = "test_user_id",
+                Username = "test_username"
+            };
 
             _httpMessageHandlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -147,21 +171,26 @@ namespace ClickUpApi.Tests
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($"{{\"username\": \"{expectedUsername}\"}}")
+                    Content = new StringContent($"{{\"id\": \"{expectedUser.Id}\", \"username\": \"{expectedUser.Username}\"}}")
                 });
 
             // Act
-            var username = await _clickUpClient.GetAuthorizedUserAsync();
+            var user = await _clickUpClient.GetAuthorizedUserAsync();
 
             // Assert
-            Assert.Equal(expectedUsername, username);
+            Assert.Equal(expectedUser.Id, user.Id);
+            Assert.Equal(expectedUser.Username, user.Username);
         }
 
         [Fact]
         public async Task GetAuthorizedTeamsAsync_ReturnsTeams()
         {
             // Arrange
-            var expectedTeams = "[{\"id\": \"team1\"}, {\"id\": \"team2\"}]";
+            var expectedTeams = new[]
+            {
+                new Team { Id = "team1" },
+                new Team { Id = "team2" }
+            };
 
             _httpMessageHandlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -172,14 +201,18 @@ namespace ClickUpApi.Tests
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent($"{{\"teams\": {expectedTeams}}}")
+                    Content = new StringContent($"{{\"teams\": [{string.Join(", ", expectedTeams.Select(t => $"{{\"id\": \"{t.Id}\"}}"))}]}}")
                 });
 
             // Act
             var teams = await _clickUpClient.GetAuthorizedTeamsAsync();
 
             // Assert
-            Assert.Equal(expectedTeams, teams);
+            Assert.Equal(expectedTeams.Length, teams.Length);
+            for (int i = 0; i < expectedTeams.Length; i++)
+            {
+                Assert.Equal(expectedTeams[i].Id, teams[i].Id);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2

Change methods in `ClickUpClient` and `IClickUpClient` to return model classes instead of strings.

* **ClickUpClient.cs**
  - Change `CreateTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `GetTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `UpdateTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `GetAuthorizedUserAsync` to return `Task<Models.User>` instead of `Task<string>`
  - Change `GetAuthorizedTeamsAsync` to return `Task<Models.Team[]>` instead of `Task<string>`

* **IClickUpClient.cs**
  - Change `CreateTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `GetTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `UpdateTaskAsync` to return `Task<Models.Task>` instead of `Task<string>`
  - Change `GetAuthorizedUserAsync` to return `Task<Models.User>` instead of `Task<string>`
  - Change `GetAuthorizedTeamsAsync` to return `Task<Models.Team[]>` instead of `Task<string>`

* **ClickupClientTests.cs**
  - Change `CreateTaskAsync_ReturnsTaskId` to expect `Models.Task` instead of `string`
  - Change `GetTaskAsync_ReturnsTaskName` to expect `Models.Task` instead of `string`
  - Change `UpdateTaskAsync_ReturnsUpdatedTaskId` to expect `Models.Task` instead of `string`
  - Change `GetAuthorizedUserAsync_ReturnsUsername` to expect `Models.User` instead of `string`
  - Change `GetAuthorizedTeamsAsync_ReturnsTeams` to expect `Models.Team[]` instead of `string`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcleigh/ClickUpApi/pull/6?shareId=5f47ad75-e875-453f-9a1e-7a405823c50c).